### PR TITLE
Fix bug - undefined promise

### DIFF
--- a/front_end/app/scripts/controllers/main.js
+++ b/front_end/app/scripts/controllers/main.js
@@ -58,10 +58,9 @@ angular.module('markNewsReaderApp')
         //Using the search endpoint
         $scope.search = function() {
 
-            if ($scope.querystring.q.length > 0) {
-                var promiseSearch = newsService.searchNews($scope.region, $scope.querystring);
-            }
-
+            // search even if the query string is empty (might be clearing the previous search)
+            var promiseSearch = newsService.searchNews($scope.region, $scope.querystring);
+            
             promiseSearch.then(function(resp) {
 
                 $scope.connectionError = false;


### PR DESCRIPTION
1. Removed the conditional declaration of promiseSearch as it causes an undefined reference error when the code outside the if block references it.
2. Allowing the user to search even if the search term is empty as they may want to clear their search criteria in this way.

Fixes #3